### PR TITLE
Security Fix for RCE on "node-svn-ultimate" - huntr.dev

### DIFF
--- a/src/externals.js
+++ b/src/externals.js
@@ -1,4 +1,4 @@
-var exec = require('child_process').exec;
+var exec = require('child_process').execFile;
 var parseString = require('xml2js').parseString;
 
 module.exports.get = function(options, next){
@@ -9,9 +9,9 @@ module.exports.get = function(options, next){
   } else if (this.remote) {
     command = command.concat([this.remote]);
   }
-  command = command.join(' ');
+  command = command.join(' ').split(' ');
 
-  exec(command, {}, function(error, stdout, stderr){
+  exec(command[0], command.slice(1), {}, function(error, stdout, stderr){
     if(error) return next(error);
 
     parseString(stdout, function(error, result){
@@ -40,9 +40,9 @@ module.exports.set = function(options, next){
   options = options || {};
   command = command.concat([this.local ? this.local : "."]);
   command = command.concat(['-F', options.file]);
-  command = command.join(' ');
+  command = command.join(' ').split(' ');
 
-  exec(command, {}, function(error, stdout, stderr){
+  exec(command[0], command.slice(1), {}, function(error, stdout, stderr){
     return next(error);
   })
 };

--- a/src/parse_info.js
+++ b/src/parse_info.js
@@ -1,7 +1,9 @@
-var exec = require('child_process').exec;
+var exec = require('child_process').execFile;
 
 module.exports = function parse_svn_info(local_repo, next){
-  var info_call = exec('svn info ' + local_repo,
+  var cmd = 'svn info ' + local_repo;
+  cmd = cmd.split(' ');
+  var info_call = exec(cmd[0], cmd.slice(1),
     function(error, stdout, stderr){
       var out_lines;
       var extractor = /^(.*): (.*)$/;


### PR DESCRIPTION
https://huntr.dev/users/Asjidkalam has fixed the RCE on "node-svn-ultimate" vulnerability 🔨. Asjidkalam has been awarded $25 for fixing the vulnerability through the huntr bug bounty program 💵. Think you could fix a vulnerability like this?
           
Get involved at https://huntr.dev/

Q | A
Version Affected | ALL
Bug Fix | YES
Original Pull Request | https://github.com/418sec/node-svn/pull/1
Vulnerability README | https://github.com/418sec/huntr/blob/master/bounties/npm/svn/1/README.md

### User Comments:

### 📊 Metadata *

Command injection vulnerability 
#### Bounty URL:  https://www.huntr.dev/bounties/1-npm-svn
### ⚙️ Description *

The svn module is vulnerable against RCE since a command is crafted using user inputs not validated and then executedading to arbitrary command injection The argument options can be controlled by users without any sanitization. It was using `exec()` function which is vulnerable to **Command Injection** if it accepts user input and it goes through any sanitization or escaping.

### 💻 Technical Description *

The use of the `child_process` function `exec()` is highly discouraged if you accept user input and don't sanitize/escape them. I replaced it with `execFile()` which mitigates any possible Command Injections as it accepts input as arrays.

### 🐛 Proof of Concept (PoC) *

The PoC given in the bounty was incorrect, here's the PoC:
Install the package and run the below code, you'll need to have a PDF to test:
```javascript
// poc.js
var SVN = require('svn');
var svn = new SVN('./working_copy');
svn.info("test; touch HACKED; #", function(){});
```
A file named `HACKED` will be created in the current working directory.

![image](https://user-images.githubusercontent.com/16708391/92593693-29ab7800-f2bf-11ea-9ffb-747f3e775bf9.png)


### 🔥 Proof of Fix (PoF) *

After applying the fix, run the PoC again and no files will be created. Hence command injection is mitigated.

![image](https://user-images.githubusercontent.com/16708391/92593777-4b0c6400-f2bf-11ea-8212-4f57dcb0cca9.png)


### 👍 User Acceptance Testing (UAT)

Only `execFile` is used, no breaking changes introduced.
